### PR TITLE
feat(carousel): Automatically advance photos

### DIFF
--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -1,15 +1,27 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function Carousel({ images }: { images: React.JSX.Element[] }) {
   const [currImage, setCurrImage] = useState(0);
+  const [intervalId, setIntervalId] = useState<NodeJS.Timeout>();
 
   const viewPrevImage = () => {
+    clearInterval(intervalId);
     setCurrImage((currImage + images.length - 1) % images.length);
   };
 
   const viewNextImage = () => {
+    clearInterval(intervalId);
     setCurrImage((currImage + 1) % images.length);
   };
+
+  useEffect(() => {
+    setIntervalId(
+      setInterval(() => {
+        setCurrImage((currImage + 1) % images.length);
+      }, 5000),
+    );
+    return () => clearInterval(intervalId);
+  }, [currImage]);
 
   return (
     <div className="carousel-container">


### PR DESCRIPTION
Add a timeout to automatically advance photos every 5 seconds. The 5 seconds resets when the user uses a button to view the next or previous photo.