### PR TITLE
perf(carousel): Add variable for numOfPhotos

### DIFF
--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -3,21 +3,22 @@ import { useState, useEffect } from "react";
 export default function Carousel({ images }: { images: React.JSX.Element[] }) {
   const [currImage, setCurrImage] = useState(0);
   const [intervalId, setIntervalId] = useState<NodeJS.Timeout>();
+  const numOfPhotos = images.length;
 
   const viewPrevImage = () => {
     clearInterval(intervalId);
-    setCurrImage((currImage + images.length - 1) % images.length);
+    setCurrImage((currImage + numOfPhotos - 1) % numOfPhotos);
   };
 
   const viewNextImage = () => {
     clearInterval(intervalId);
-    setCurrImage((currImage + 1) % images.length);
+    setCurrImage((currImage + 1) % numOfPhotos);
   };
 
   useEffect(() => {
     setIntervalId(
       setInterval(() => {
-        setCurrImage((currImage + 1) % images.length);
+        setCurrImage((currImage + 1) % numOfPhotos);
       }, 5000),
     );
     return () => clearInterval(intervalId);


### PR DESCRIPTION
Add the variable, numOfPhotos, instead of repeatedly calculating images.length for a slight improvement in performance.