### PR TITLE
feat(carousel): Add navigation dots below photos

### DIFF
--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -24,11 +24,27 @@ export default function Carousel({ images }: { images: React.JSX.Element[] }) {
     return () => clearInterval(intervalId);
   }, [currImage]);
 
+  const navigateToPhoto = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setCurrImage(parseInt(e.target.id));
+  };
+
   return (
     <div className="carousel-container">
-      <button onClick={viewPrevImage}>Back</button>
-      {images[currImage]}
-      <button onClick={viewNextImage}>Next</button>
+      <div className="image-container">
+        <button onClick={viewPrevImage}>Back</button>
+        {images[currImage]}
+        <button onClick={viewNextImage}>Next</button>
+      </div>
+      <nav>
+        {[...Array(numOfPhotos)].map((_, i) => (
+          <button
+            key={i}
+            id={`${i}`}
+            className={`circle ${i === currImage ? "selected" : ""}`}
+            onClick={navigateToPhoto}
+          ></button>
+        ))}
+      </nav>
     </div>
   );
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import "../styles/global.css";
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,0 +1,10 @@
+.circle {
+  border-radius: 50%;
+  height: 15px;
+  width: 10px;
+  margin: 3px;
+}
+
+.selected {
+  background-color: black;
+}


### PR DESCRIPTION
Add navigation dots, one representing each photo, below the image carousel. Link CSS to make the dots circular. Dots fill in when the photo they represent is displayed.